### PR TITLE
Updater-stuff: Add Raphael to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -19,5 +19,26 @@
             "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
          }
       ]
+   },
+   {
+      "name": "Redmi K20 Pro / Mi 9T Pro",
+      "brand": "Xiaomi",
+      "codename": "raphael",
+      "supported_versions": [
+         {
+            "version_code": "android_10",
+            "version_name": "Ten",
+            "maintainer_name": "Alexandru Scurtu",
+            "maintainer_url": "https://github.com/sashascurtu",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         },
+         {
+            "version_code": "android_10-official",
+            "version_name": "10 (Official)",
+            "maintainer_name": "Alexandru Scurtu",
+            "maintainer_url": "https://github.com/sashascurtu",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Xiaomi Redmi K20 Pro / Mi 9T Pro (raphael)

Device tree: https://github.com/sashascurtu/android_device_xiaomi_raphael

Kernel source: Prebuilt

Current Linux subversion: 4.14.117

Reason for prebuilt kernel (if exists): Issues with FOD on custom kernels (with AOD and DC Dimming)

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: sashascurtu

Telegram username: @san9scurtu