### PR TITLE
updater-stuff: Add davinci to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -21,6 +21,27 @@
       ]
    },
    {
+      "name": "Redmi K20 / Mi 9T",
+      "brand": "Xiaomi",
+      "codename": "davinci",
+      "supported_versions": [
+         {
+            "version_code": "android_10",
+            "version_name": "Ten",
+            "maintainer_name": "criticalerror99",
+            "maintainer_url": "https://github.com/criticalerror99",
+            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4137423"
+         },
+         {
+            "version_code": "android_10-official",
+            "version_name": "10 (Official)",
+            "maintainer_name": "criticalerror99",
+            "maintainer_url": "https://github.com/criticalerror99",
+            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4137423"
+         }
+      ]
+   }
+   {
       "name": "Redmi K20 Pro / Mi 9T Pro",
       "brand": "Xiaomi",
       "codename": "raphael",


### PR DESCRIPTION
Device and codename: Xiaomi Redmi K20 / Mi 9T (davinci)

Device tree: https://github.com/criticalerror99/android_device_xiaomi_davinci

Kernel source: https://github.com/vantoman/kernel_xiaomi_davinci

Current Linux subversion: 4.14.193

Selinux: Permissive

Safetynet status: Pass without Magisk

Sourceforge username: critical99

Telegram username: criticalerror99

XDA Thread (if exists): https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4137423

XDA Profile (if exists): https://forum.xda-developers.com/member.php?u=10116182