### PR TITLE
Updater-stuff: Add Miatoll to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -82,5 +82,26 @@
             "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
          }
       ]
+   },
+   {
+      "name": "Redmi Note 9S / 9 Pro / 9 Pro Max / Poco M2 Pro ",
+      "brand": "Xiaomi",
+      "codename": "miatoll",
+      "supported_versions": [
+         {
+            "version_code": "android_10",
+            "version_name": "Ten",
+            "maintainer_name": "Ahmed Tohamy (Agmad),
+            "maintainer_url": "https://github.com/ahmedtohamy1",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         },
+         {
+            "version_code": "android_10-official",
+            "version_name": "10 (Official)",
+            "maintainer_name": "Ahmed Tohamy (Agmad)",
+            "maintainer_url": "https://github.com/ahmedtohamy1",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Xiaomi Redmi Note 9S / 9 Pro / 9 Pro Max / Poco M2 Pro

Device tree: https://github.com/ahmedtohamy1/device_xiaomi_sm6250-common-old

Kernel source: https://github.com/vantoman/kernel_xiaomi_curtana

Current Linux subversion: 4.14.196

Selinux: permissive

Safetynet status: Pass without Magisk

Sourceforge username: ahmedtohamy

Telegram username: @ahmed_tohamy