### PR TITLE
updater-stuff: Add lavender to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1,5 +1,26 @@
 [
    {
+      " nome " : " Redmi Note 7 " ,
+      " marca " : " Xiaomi " ,
+      " codinome " : " lavender " ,
+      " supported_versions " : [
+         {
+            " version_code " : " android_11 " ,
+            " version_name " : " Eleven " ,
+            " Maintainer_name " : " CHRISL7 " ,
+            " keeper_url " : " https://https://github.com/ChrisW444 " ,
+            " xda_thread " : " "
+         },
+         {
+            " version_code " : " android_11-official " ,
+            " version_name " : " 11 (oficial) " ,
+            " Maintainer_name " : " CHRISL7 " ,
+            " keeper_url " : " https://https://github.com/ChrisW444 " ,
+            " xda_thread " : " "
+         }
+      ]
+   },
+   {
       "name": "6T",
       "brand": "OnePlus",
       "codename": "fajita",


### PR DESCRIPTION
Device and codename: Redmi note 7 - Lavender

Device tree: https://github.com/ChrisW444/android_xiaomi_lavender (It's private, someone from the team contact me to let me access)

Kernel source: https://github.com/stormbreaker-project/kernel_xiaomi_lavender

Current Linux subversion: 4.4.241

Reason for prebuilt kernel (if exists): Because it is made by a great developer for lavender, who is always updating it and is already bringing Selinux version 4.14 to lavender

Selinux: Permissive

Safetynet status: Pass without Magisk

Sourceforge username: https://sourceforge.net/u/chrisw444/profile

Telegram username: @CHRISL7

XDA Thread (if exists):

XDA Profile (if exists):