### PR TITLE
devices: Switch Maintainers of Xiaomi Mi 9T/Redmi K20 (davinci)

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -26,18 +26,18 @@
       "codename": "davinci",
       "supported_versions": [
          {
-            "version_code": "android_10",
-            "version_name": "Ten",
-            "maintainer_name": "criticalerror99",
-            "maintainer_url": "https://github.com/criticalerror99",
-            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4137423"
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "ArixElo",
+            "maintainer_url": "https://github.com/ArixElo",
+            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4196017"
          },
          {
-            "version_code": "android_10-official",
-            "version_name": "10 (Official)",
-            "maintainer_name": "criticalerror99",
-            "maintainer_url": "https://github.com/criticalerror99",
-            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4137423"
+            "version_code": "android_11-official",
+            "version_name": "11 (Official)",
+            "maintainer_name": "ArixElo",
+            "maintainer_url": "https://github.com/ArixElo",
+            "xda_thread": "https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4196017"
          }
       ]
    },


### PR DESCRIPTION
Previous maintainer was inactive and he changed his phone to Xiaomi Mi 10 (umi) so i want to maintain davinci with his agree.

Signed-off-by: ArixElo <patroxgamer@gmail.com>

Device and codename: Redmi K20/Mi 9T

Device tree: https://github.com/ArixElo/device_xiaomi_davinci

Kernel source: https://github.com/vantoman/kernel_xiaomi_davinci

Current Linux subversion: 4.14.209

Reason for prebuilt kernel (if exists): not using

Selinux: Enforcing

Safetynet status: Pass with Magisk

Sourceforge username: arixelo

Telegram username: @ArixElo

XDA Thread (if exists): https://forum.xda-developers.com/mi-9t/development/rom-shapeshiftos-t4196017

XDA Profile (if exists): https://forum.xda-developers.com/member.php?u=7618683