### PR TITLE
updater-stuff: Add jasmine_sprout to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -124,5 +124,19 @@
             "xda_thread": "https://forum.xda-developers.com/redmi-note-7-pro/development/rom-shapeshiftos-t4111387"
          }
       ]
+   },
+   {
+      "name": "Xiaomi Mi A2",
+      "brand": "Xiaomi",
+      "codename": "jasmine_sprout",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "clarencelol",
+            "maintainer_url": "https://github.com/clarencelol",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0_r16-unofficial-stable-shapeshiftos-jasmine_sprout-mi-a2.4207051/"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Xiaomi Mi A2 (jasmine_sprout)

Device tree: https://github.com/clarencelol/device_xiaomi_jasmine_sprout
Device Common tree: https://github.com/clarencelol/device_xiaomi_sdm660-common
Kernel source: https://github.com/clarencelol/kernel_xiaomi_sdm660

Current Linux subversion: 4.4.248

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: clarencelol

Telegram username: clarencelol

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r16-unofficial-stable-shapeshiftos-jasmine_sprout-mi-a2.4207051/

XDA Profile (if exists): https://forum.xda-developers.com/m/clarencek.7812700/