### PR TITLE
updater-stuff: Add X01BD to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -138,5 +138,19 @@
             "xda_thread": "https://forum.xda-developers.com/t/rom-11-0_r16-unofficial-stable-shapeshiftos-jasmine_sprout-mi-a2.4207051/"
          }
       ]
+    },
+    {
+      "name": "Zenfone Max Pro M2",
+      "brand": "ASUS",
+      "codename": "X01BD"
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "Rams-ek",
+            "maintainer_url": "https://github.com/BloodyHeartR/",
+            "xda_thread": "https://forum.xda-developers.com/t/unofficial-a11-shapeshift-os-stable-x01bd.4209241/"
+         }
+      ]
    }
 ]

--- a/devices.json
+++ b/devices.json
@@ -141,14 +141,14 @@
     },
     {
       "name": "Zenfone Max Pro M2",
-      "brand": "ASUS",
+      "brand": "Asus",
       "codename": "X01BD"
       "supported_versions": [
          {
             "version_code": "android_11",
             "version_name": "Eleven",
             "maintainer_name": "Rams-ek",
-            "maintainer_url": "https://github.com/BloodyHeartR/",
+            "maintainer_url": "https://github.com/Rams-ek",
             "xda_thread": "https://forum.xda-developers.com/t/unofficial-a11-shapeshift-os-stable-x01bd.4209241/"
          }
       ]


### PR DESCRIPTION
Device and codename:  Asus ZenFone Max Pro M2 (X01BD)

Device tree: https://github.com/BloodyHeartR/device-asus-sdm660

Kernel source: https://github.com/BloodyHeartR/asus-kernel-sdm660

Current Linux subversion: 4.4.227

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: ramsek

Telegram username: rams_ek

XDA Thread (if exists): https://forum.xda-developers.com/t/unofficial-a11-shapeshift-os-stable-x01bd.4209241/

XDA Profile (if exists): https://forum.xda-developers.com/m/rams-ek.11331513/