### PR TITLE
updater-stuff: Add Violet to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -138,5 +138,19 @@
             "xda_thread": "https://forum.xda-developers.com/t/rom-11-0_r16-unofficial-stable-shapeshiftos-jasmine_sprout-mi-a2.4207051/"
          }
       ]
+   },
+   {
+      "name": "Redmi Note 7 Pro",
+      "brand": "Xiaomi",
+      "codename": "violet",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "galanteria01",
+            "maintainer_url": "https://github.com/galanteria01",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Redmi Note 7 Pro <violet>

Device tree: https://github.com/galanteria01/android_device_xiaomi_violet

Kernel source: https://github.com/Panchajanya1999/msm-4.14

Current Linux subversion: 4.14.212

Reason for prebuilt kernel (if exists): LTO crashing while building due to weak server.

Selinux: Enforcing

Safetynet status:Pass with Magisk

Sourceforge username: galanteria01

Telegram username: @galanteria01

XDA Thread (if exists): https://en.m.wikipedia.org/wiki/HTTP_404

XDA Profile (if exists): https://forum.xda-developers.com/m/shanuu18.10001639/