### PR TITLE
Update devices.json

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -210,3 +210,18 @@
       ]
    }
 ]
+  {
+      "name": "Poco F2 Pro | Redmi k30 Pro",
+      "brand": "Poco",
+      "codename": "lmi/lmipro",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "soumyo19",
+            "maintainer_url": "https://github.com/soumyo19",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-unofficial-stable-lmi-shapeshift-os-2-2-2021-01-30.4225771/"
+         }
+      ]
+   }
+]


### PR DESCRIPTION
Device and codename: Poco F2 Pro | Redmi k30 Pro (lmi/lmipro)

Device tree: https://github.com/soumyo19/device_xiaomi_lmi.git

Kernel source: https://bigota.d.miui.com/V12.2.4.0.RJKMIXM/miui_LMIGlobal_V12.2.4.0.RJKMIXM_682e9ad14f_11.0.zip

Current Linux subversion: Linux-5.4.0-1036-gcp-x86_64-Ubuntu-20.04.1-LTS

Reason for prebuilt kernel (if exists): No Custom Kernels yet available for a11

Selinux: permissive

Safetynet status: Pass with Magisk

Sourceforge username: dont use

Telegram username: @soumyo19

XDA Thread: https://forum.xda-developers.com/t/rom-11-0-unofficial-stable-lmi-shapeshift-os-2-2-2021-01-30.4225771/

XDA Profile: https://forum.xda-developers.com/m/fahmid-islam-soumya.8489030/