### PR TITLE
Update devices.json

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -208,5 +208,19 @@
             "xda_thread": "https://forum.xda-developers.com/t/unofficial-a11-shapeshift-os-stable-x01bd.4209241/"
          }
       ]
+   },
+   {
+      "name": "Xiaomi POCO X3 (NFC)",
+      "brand": "Xiaomi",
+      "codename": "surya",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "Roxirp",
+            "maintainer_url": "https://github.com/roxipro",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+        }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename:Xiaomi POCO X3 | (NFC)  (surya/karna

Device tree:https://github.com/roxipro/device_xiaomi_surya

Kernel source:https://github.com/roxipro/kernel_xiaomi_surya

Current Linux subversion:4.14.117

Reason for prebuilt kernel (if exists): doesen't exist

Selinux: Enforcing

Safetynet status:Pass without Magisk

Sourceforge username:Roxirp

Telegram username:@rkxirp

XDA Thread (if exists):none

XDA Profile (if exists):Roxirp12