### PR TITLE
POCO X3 - Android 11

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -133,6 +133,20 @@
     ]
   },
   {
+    "name": "POCO X3 (NFC)",
+    "brand": "Xiaomi",
+    "codename": "karna/surya",
+    "supported_versions": [
+      {
+        "version_code": "android_11",
+        "version_name": "Eleven",
+        "maintainer_name": "bicet",
+        "maintainer_url": "https://github.com/bicet",
+        "xda_thread": "https://www.lego.com/en-gb/404?CMP=AFC-AffiliateUK-kXQk6*ivFEQ-2294204-124738-1"
+      }
+    ]
+  },
+  {
     "name": "Zenfone Max Pro M2",
     "brand": "Asus",
     "codename": "X01BD",


### PR DESCRIPTION
Device and codename: Poco X3 (NFC) [karna (surya)]

Device tree: https://github.com/Bicet/device_xiaomi_surya/tree/eleven-ssos / https://github.com/Bicet/vendor_xiaomi_surya/tree/eleven-ssos

Kernel source: https://github.com/Bicet/kernel_xiaomi_surya

Current Linux subversion: 4.14.221

Reason for prebuilt kernel (if exists): none

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: bicet

Telegram username: bicet

XDA Thread (if exists): I don't like XDA, I'm a really senior user there (sept. 2008), and it has lost its initial spirit...so I would love to avoid it as much as I can

XDA Profile (if exists): https://forum.xda-developers.com/m/bicet.1230259/