### PR TITLE
Maintainer application for maintaining ShapeShiftOS for Redmi Note 7/7S

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -224,3 +224,17 @@
       ]
    }
 ]
+      "name": "Xiaomi Redmi Note 7",
+      "brand": "Xiaomi",
+      "codename": "lavender",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "Brian Jose",
+            "maintainer_url": "https://github.com/whtisusername",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-2-marshtomp.4225111/"
+         }
+      ]
+   },
+   {

--- a/devices.json
+++ b/devices.json
@@ -233,7 +233,7 @@
             "version_name": "Eleven",
             "maintainer_name": "Brian Jose",
             "maintainer_url": "https://github.com/whtisusername",
-            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-2-marshtomp.4225111/"
+            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-4-treecko.4225111/"
          }
       ]
    },


### PR DESCRIPTION
Device and codename: Xiaomi Redmi Note 7/7S (Lavender)

Device tree: github.com/whtisusername/device_xiaomi_lavender

Kernel source: github.com/whtisusername/kernel_xiaomi_lavender

Current Linux subversion: 4.4.252

Reason for prebuilt kernel (if exists): No I don't use a prebuilt kernel.

Selinux: Permissive

Safetynet status: Pass with and without Magisk

Sourceforge username: bj123

Telegram username: @whtisusername

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-4-treecko.4225111/

XDA Profile (if exists): https://forum.xda-developers.com/m/brian-jose.10601901/