### PR TITLE
Add RMX1971 - Realme 5 Pro

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -187,5 +187,19 @@
         "xda_thread": "https://forum.xda-developers.com/t/rom-11-0_r27-unofficial-stable-shapeshiftos-rmx1851.4239305/"
       }
     ]
+  },
+  {
+    "name": "Realme 5 Pro",
+    "brand": "Realme",
+    "codename": "RMX1971",
+    "supported_versions": [
+      {
+        "version_code": "android_11",
+        "version_name": "Eleven",
+        "maintainer_name": "goshawk22",
+        "maintainer_url": "https://github.com/goshawk22",
+        "xda_thread": "https://forum.xda-developers.com/t/rom-11-unofficial-shapeshiftos-swampert-for-realme-5-pro.4241353/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Device and codename: Realme 5 Pro | RMX1971

Device tree: https://github.com/goshawk22/device_realme_RMX1971

Kernel source: https://github.com/dotOS-Devices/android_kernel_realme_RMX1971

Current Linux subversion: 4.9

Reason for prebuilt kernel (if exists): It doesn't

Selinux: Enforcing

Safetynet status: Pass without Magisk/Pass with Magisk

Sourceforge username: goshawk22

Telegram username: goshawk22

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-unofficial-shapeshiftos-swampert-for-realme-5-pro.4241353/

XDA Profile (if exists): https://forum.xda-developers.com/m/goshawk22.9108029/