### PR TITLE
updater-stuff: Add RMX1851 to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -173,5 +173,19 @@
         "xda_thread": "https://forum.xda-developers.com/t/unofficial-a11-shapeshift-os-stable-x01bd.4209241/"
       }
     ]
+  },
+  {
+    "name": "Realme 3 Pro",
+    "brand": "Realme",
+    "codename": "RMX1851",
+    "supported_versions": [
+      {
+        "version_code": "android_11",
+        "version_name": "Eleven",
+        "maintainer_name": "KKShedge",
+        "maintainer_url": "https://github.com/KrishnakantShedge",
+        "xda_thread": "https://forum.xda-developers.com/t/rom-11-0_r27-unofficial-stable-shapeshiftos-rmx1851.4239305/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Device and codename: Realme 3 Pro (RMX1851)

Device tree: https://github.com/KrishnakantShedge/ssos_device_realme_RMX1851

Kernel source: https://github.com/KrishnakantShedge/kernel_realme_RMX1851 (Custom kernel)

Current Linux subversion: 4.9.263

Reason for prebuilt kernel (if exists):

Selinux: Enforcing

Safetynet status: Passes without Magisk

Sourceforge username: kkshedge

Telegram username: @KKShedge

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r27-unofficial-stable-shapeshiftos-rmx1851.4239305/

XDA Profile (if exists): https://forum.xda-developers.com/m/kkshedge.9764305/