### PR TITLE
Add Lavender - Redmi Note 7/7S

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -147,6 +147,20 @@
     ]
   },
   {
+      "name": "Xiaomi Redmi Note 7/7S",
+      "brand": "Xiaomi",
+      "codename": "Lavender",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "Brian Jose",
+            "maintainer_url": "https://github.com/whtisusername",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-5-grovyle-unofficial.4258587/"
+      }
+    ]
+  },
+  {
     "name": "Xiaomi Redmi 4a",
     "brand": "Xiaomi",
     "codename": "rolex",


### PR DESCRIPTION
Device and codename: Xiaomi Redmi Note 7/7S (Lavender)

Device tree: https://github.com/whtisusername/device_xiaomi_lavender

Kernel source: https://github.com/stormbreaker-project/kernel_xiaomi_lavender/tree/oldcam-eas

Current Linux subversion: 4.4.263

Reason for prebuilt kernel (if exists): No I don't use a prebuilt kernel.

Selinux: Permissive

Safetynet status: Pass with and without Magisk

Sourceforge username: bj123

Telegram username: @whtisusername

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0-unofficial-shapeshiftos-2-5-grovyle-unofficial.4258587/

XDA Profile (if exists): https://forum.xda-developers.com/m/brian-jose.10601901/