### PR TITLE
Updater-stuff: Add sanders to official device

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -264,5 +264,19 @@
             "xda_thread":"https://en.m.wikipedia.org/wiki/HTTP_404"
          }
       ]
+   },
+   {
+      "name":"Moto G5S Plus",
+      "brand":"Motorola",
+      "codename":"sanders",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Mayur Varde",
+            "maintainer_url":"https://github.com/marshmello61",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-sanders.4259701/"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Motorola Moto G5S Plus (sanders)

Device tree: https://github.com/marshmello61/device_ssos

Kernel source: https://github.com/OctaviOS-Devices/kernel_motorola_sanders

Current Linux subversion: 3.18.140

Reason for prebuilt kernel (if exists): -

Selinux: Permissive

Safetynet status: Passes with and without Magisk

Sourceforge username: marshmello61

Telegram username: @marshmello_61

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-sanders.4259701/

XDA Profile (if exists): https://forum.xda-developers.com/m/marshmello_61.9134270/

Signed-off-by: marshmello61 <ultramayur123@gmail.com>