### PR TITLE
Poco x2 official support

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -278,5 +278,18 @@
             "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-sanders.4259701/"
          }
       ]
+   },
+   {
+      "name":"X2",
+      "brand":"Xiaomi",
+      "codename":"phoenix",
+      "supported_versions":[
+         {
+            "version_code":"android_11",                                                 "version_name":"eleven",
+            "maintainer_name":"Ankan Ghosh",
+            "maintainer_url":"https://github.com/ankan005",
+            "xda_thread":"right now not available will make"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Poco X2/ Redmi K30 phoenix

Device tree: https://github.com/ankan005/device-Xiaomi-Phoenixin/tree/ssos

Kernel source: https://github.com/ArrowOS-Devices/android_kernel_xiaomi_phoenix

Current Linux subversion: 4.14

Reason for prebuilt kernel (if exists): No

Selinux: Enforcing

Safetynet status: Pass without Magisk/

Sourceforge username: Ankan12345

Telegram username: @ankan005

XDA Thread (if exists):

XDA Profile (if exists): https://forum.xda-developers.com/m/ankan005.8237325/