### PR TITLE
Updater-stuff: Add phoenix to official device

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -278,5 +278,19 @@
             "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-sanders.4259701/"
          }
       ]
+   },
+   {
+      "name":"POCO X2",
+      "brand":"Xiaomi",
+      "codename":"phoenix",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Mihir Sahay",
+            "maintainer_url":"https://github.com/mihirsahay",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-phoenix-phoenixin.4272411/"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: Poco X2  (phoenix)

Device tree: https://github.com/Mihirsahay/device_xiaomi_phoenix

Kernel source: https://github.com/redcliff-op/android_kernel_xiaomi_phoenix

Current Linux subversion: 4.14.232

Reason for prebuilt kernel (if exists): -

Selinux: Enforcing

Safetynet status: Passes with and without Magisk

Sourceforge username: ded--me

Telegram username: @mihirsahay

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r34-unofficial-stable-shapeshiftos-phoenix-phoenixin.4272411/

XDA Profile (if exists): https://forum.xda-developers.com/m/mihirsahay.9344525/