### PR TITLE
devices: Add Xiaomi Redmi Note 4 (mido) to offcial roaster

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -70,6 +70,20 @@
       ]
    },
    {
+      "name": "Redmi Note 4",
+      "brand": "Xiaomi",
+      "codename": "mido",
+      "supported_versions": [
+         {
+            "version_code": "android_11",
+            "version_name": "Eleven",
+            "maintainer_name": "ArixElo",
+            "maintainer_url": "https://github.com/ArixElo",
+            "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
+         }
+      ]
+   },
+   {
       "name":"Mi A2",
       "brand":"Xiaomi",
       "codename":"jasmine_sprout",


### PR DESCRIPTION
Signed-off-by: ArixElo <patroxgamer@gmail.com>

Device and codename: Redmi Note 4 (mido)

Device tree: https://github.com/ArixElo/device_xiaomi_mido

Kernel source: https://github.com/zeelog/android_kernel_xiaomi_mido

Current Linux subversion: 4.9.268

Reason for prebuilt kernel (if exists): not using

Selinux: Enforcing

Safetynet status: Pass with Magisk

Sourceforge username: arixelo

Telegram username: @ArixElo

XDA Thread (if exists): https://en.m.wikipedia.org/wiki/HTTP_404

XDA Profile (if exists): https://forum.xda-developers.com/member.php?u=7618683