### PR TITLE
Add support for POCO X3 (NFC)

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -334,5 +334,19 @@
             "xda_thread":"https://i.imgur.com/gBOqhAv.png"
          }
       ]
+   },
+   {
+      "name":"POCO X3 (NFC)",
+      "brand":"Xiaomi",
+      "codename":"surya",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"GtrCraft",
+            "maintainer_url":"https://github.com/GtrCraft",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r37-unofficial-stable-shapeshiftos-surya.4278673/"
+         }
+      ]
    }
 ]


### PR DESCRIPTION
Device and codename: POCO X3 (NFC)

Device tree: https://github.com/GtrCraft/device_xiaomi_surya/tree/android_11

Common tree: https://github.com/GtrCraft/device_xiaomi_sm6150-common/tree/android_11

Kernel source: https://github.com/GZR-Kernels/Optimus_Drunk_Surya/tree/11.0

Current Linux subversion: 4.14.190

Reason for prebuilt kernel (if exists):

Selinux: Enforcing

Safetynet status: Pass without Magisk/Pass with Magisk

Sourceforge username: GtrCraft

Telegram username: @NickvBokhorst

XDA Thread (if exists): https://forum.xda-developers.com/t/title-rom-11-0_r37-unofficial-stable-shapeshiftos-surya.4278673/

XDA Profile (if exists): https://forum.xda-developers.com/m/gtrcraft.5293805/