### PR TITLE
Add Support for Xiaomi Redmi Note 5 Pro

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -336,3 +336,18 @@
       ]
    }
 ]
+{
+      "name":"Redmi Note 5 Pro",
+      "brand":"Xiaomi",
+      "codename":"whyred",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Arnav",
+            "maintainer_url":"https://github.com/arnavpuranik",
+            "xda_thread":"https://i.imgur.com/gBOqhAv.png"
+         }
+      ]
+   }
+]


### PR DESCRIPTION
Device and codename: Xiaomi Redmi Note 5 Pro - Whyred 

Device tree: https://github.com/arnavpuranik/whyred-device/tree/ssos

Kernel source: https://github.com/arnavpuranik/kranul

Current Linux subversion: 4.4.268

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: arnavpuranik

Telegram username: arnavpuranik