### PR TITLE
Add support Realme X2

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -306,8 +306,8 @@
             "xda_thread":"https://i.imgur.com/gBOqhAv.png"
          }
       ]
-   },
-   {
+  },
+  {
     "name": "Redmi Note 9 Pro / 9S / 9 Pro Max / Poco M2 Pro",
     "brand": "Xiaomi",
     "codename": "miatoll",
@@ -320,5 +320,19 @@
         "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
       }
     ]
+  },
+  {
+      "name":"Realme X2",
+      "brand":"Realme",
+      "codename":"X2",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Retypolkg",
+            "maintainer_url":"https://github.com/Retypolkg",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0-unofficial-stable-shapeshiftos-realme-x2.4290745/"
+         }
+      ]
   }
 ]


### PR DESCRIPTION
Device and codename: Realme X2 (X2)

Device tree: https://github.com/Retypolkg/device_realme_X2

Kernel source: https://github.com/Retypolkg/kernel_realme_sm6150

Current Linux subversion: 4.14.117

Reason for prebuilt kernel (if exists):

Selinux: permissive, I tried enforcing and it worked, but there were denials I couldn't resolve

Safetynet status: Pass without Magisk

Sourceforge username: Retypolkg

Telegram username: Retypolkg

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0-unofficial-stable-shapeshiftos-realme-x2.4290745/

XDA Profile (if exists): https://forum.xda-developers.com/m/retypolkg.10541651/