### PR TITLE
Add mojito/sunny (Xiaomi Redmi Note 10).

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -320,5 +320,19 @@
         "xda_thread": "https://en.m.wikipedia.org/wiki/HTTP_404"
       }
     ]
-  }
+   },
+   {
+      "name":"Xiaomi Redmi Note 10",
+      "brand":"Xiaomi",
+      "codename":"mojito",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Antoni Bal (mlodybalu)",
+            "maintainer_url":"https://github.com/lukizel",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r37-unofficial-stable-shapeshiftos-mojito.4291603/"
+         }
+      ]
+   }
 ]


### PR DESCRIPTION
Device and codename: Xiaomi Redmi Note 10 (mojito/sunny)
Device tree: https://github.com/lukizel/android_device_xiaomi_mojito/tree/shapeshift
Kernel source: https://github.com/PixelExperience-Devices/kernel_xiaomi_mojito
Current Linux subversion: 4.14.190
Reason for pre-built kernel (if exists): n/a
Selinux: Enforcing
Safetynet status: Passed with Magisk (basic+cts) on default device fingerprints.
Sourceforge username: mlodybalu
Telegram username: mlodybalu
XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r37-unofficial-stable-shapeshiftos-mojito.4291603/
XDA Profile (if exists): https://forum.xda-developers.com/m/fajormein.6004662/
