### PR TITLE
devices: Add Poco X3 Pro

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -252,6 +252,20 @@
       ]
    },
    {
+      "name":"POCO X3 Pro",
+      "brand":"Xiaomi",
+      "codename":"vayu",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_url":"https://github.com/xawlw",
+            "maintainer_name":"xawlw",
+            "xda_thread":"https://bit.ly/3z2DhZg"
+         }
+      ]
+   },
+   {
       "name":"F3",
       "brand":"POCO",
       "codename":"alioth",


### PR DESCRIPTION
Device and codename: Poco X3 Pro (vayu)

Device tree: https://github.com/xawlw/android_device_xiaomi_vayu

Kernel source: https://github.com/xawlw/android_kernel_xiaomi_vayu

Current Linux subversion: 4.14.239

Reason for prebuilt kernel (if exists):

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: xawlw

Telegram username: xawlw

XDA Thread (if exists):

XDA Profile (if exists):