### PR TITLE
Updater:Stuff- Add back RMX1971 to official devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -154,6 +154,20 @@
       ]
    },
    {
+      "name":"5 Pro",
+      "brand":"Realme",
+      "codename":"RMX1971",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Krish Walecha",
+            "maintainer_url":"https://github.com/Mxlfunction",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-unofficial-shapeshiftos-for-realme-5-pro-rmx1971.4318445/"
+         }
+      ]
+   },
+   {
       "name":"8T",
       "brand":"OnePlus",
       "codename":"kebab",


### PR DESCRIPTION
Device and codename: Realme 5 Pro (RMX1971)

Device tree: https://github.com/KrishWalecha/android_device_realme_RMX1971 & https://github.com/KrishWalecha/android_device_realme_sdm710-common

Kernel source: https://github.com/KrishWalecha/kernel_realme_RMX1971

Current Linux subversion: 4.9.277

Selinux: Enforcing

Safetynet status: Pass with Magisk

Sourceforge username: krishw

Telegram username: Mxlfunction

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-unofficial-shapeshiftos-for-realme-5-pro-rmx1971.4318445/

XDA Profile (if exists): https://forum.xda-developers.com/m/krishwalecha098.9120018/