### PR TITLE
Updater-stuff: Add RMX2170 (Realme 7 Pro) to official device

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -348,5 +348,19 @@
             "xda_thread":"https://forum.xda-developers.com/t/rom-11-0-unofficial-stable-shapeshiftos-realme-x2.4290745/"
          }
       ]
+   },
+   {
+      "name":"Realme 7 Pro",
+      "brand":"Realme",
+      "codename":"RMX2170",
+      "supported_versions":[
+         {
+            "version_code":"android_11",
+            "version_name":"eleven",
+            "maintainer_name":"Mayur Varde",
+            "maintainer_url":"https://github.com/marshmello61",
+            "xda_thread":"https://forum.xda-developers.com/t/rom-11-0_r37-unofficial-stable-shapeshiftos-for-realme-7-pro-rmx2170.4294245/"
+         }
+      ]
   }
 ]


### PR DESCRIPTION
Device and codename: Realme 7 Pro (RMX2170)

Device tree: https://github.com/realme-sm7125/ssos_realme7pro/tree/device

Common tree: https://github.com/realme-sm7125/ssos_realme7pro/tree/common

Kernel source: Prebuilt

Current Linux subversion: 4.14.180

Reason for prebuilt kernel (if exists): Coz realme didn't released 11 kernel source and 10 kernel source doesn't seem to boot on 11

Selinux: Enforcing

Safetynet status: Passes with and without Magisk

Sourceforge username: marshmello61

Telegram username: @marshmello_61

XDA Thread (if exists): https://forum.xda-developers.com/t/rom-11-0_r37-unofficial-stable-shapeshiftos-for-realme-7-pro-rmx2170.4294245/

XDA Profile (if exists): https://forum.xda-developers.com/m/marshmello_61.9134270/

Signed-off-by: Mayur <ultramayur123@gmail.com>