### PR TITLE
devices: mido -> gauguin

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -139,11 +139,11 @@
         "support_group": "https://t.me/BotsGarage",
         "tg_id": 1380028411
       },
-      "mido": {
-        "name": "Redmi Note 4",
+      "gauguin": {
+        "name": "Mi 10T Lite/Mi 10i/Redmi Note 9 Pro 5G",
         "maintainer": "ArixElo",
         "xda_thread": null,
-        "support_group": null,
+        "support_group": "https://t.me/arixelogroup",
         "tg_id": 479653169
       },
       "phoenix": {


### PR DESCRIPTION
mido is dropped because of cancerous community, and gauguin will replace it

Signed-off-by: ArixElo <patroxgamer@gmail.com>

devices: gauguin: Add missing https://

Signed-off-by: ArixElo <patroxgamer@gmail.com>

Device and codename: Xiaomi Mi10T Lite/Mi 10i/ Redmi Note 9 Pro 5G (gauguin)

Device tree: https://github.com/ArixElo/device_xiaomi_gauguin

Kernel source: Prebuilt

Current Linux subversion: 4.19.113

Reason for prebuilt kernel (if exists): It has Mi Turbo Charging working, and there's no difference between OSS version than this one in terms of performance

Selinux: Enforcing

Safetynet status: Pass without Magisk

Sourceforge username: arixelo

Telegram username: ArixElo

XDA Thread (if exists): no it doesn't

XDA Profile (if exists): patroxgamer

