### PR TITLE
Add vince to official device list

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -212,6 +212,14 @@
         "xda_thread": null,
         "support_group": null,
         "tg_id": 376528543
+      },
+      "vince": {
+	"name": "Xiaomi Redmi 5 Plus",
+	"maintainer": "GhostMaster69-dev",
+	"supported": true,
+	"xda_thread": null,
+	"support_group": null,
+	"tg_id":"1618696707"
       }
     }
   ]


### PR DESCRIPTION
Device: Xiaomi Redmi 5 Plus/Note 5 India

Codename: vince

Device tree:
https://github.com/GhostMaster69-dev/android_device_xiaomi_vince

Vendor tree:
https://github.com/GhostMaster69-dev/android_vendor_xiaomi_vince

Kernel source:
https://github.com/GhostMaster69-dev/android_kernel_xiaomi_vince

Current Linux subversion: 4.9.288

Selinux: Enforcing

Safetynet status: Pass without Magisk and Pass with Magisk

Sourceforge username: ghostmaster69

Telegram username: @GhostMaster69_dev

Signed-off-by: GhostMaster69-dev <rathore6375@gmail.com>