### PR TITLE
devices: Add support Redmi Note 10 Pro

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -212,6 +212,14 @@
         "xda_thread": null,
         "support_group": null,
         "tg_id": 376528543
+      },
+      "sweet": {
+        "name": "Redmi Note 10 Pro",
+        "maintainer": "Ken_kaneki_69",
+        "supported": true,
+        "xda_thread": null,
+        "support_group": null,
+        "tg_id": 1248206607
       }
     }
   ]


### PR DESCRIPTION
Device and codename: Redmi Note 10 pro (sweet)
Device tree: https://github.com/dhimanparas20/device-xiaomi-sweet.git
Device Common tree: https://github.com/dhimanparas20/device_xiaomi_sm6150-common.git
Kernel source: https://github.com/vantoman/kernel_xiaomi_sm6150/tree/courbet
Selinux: Enforcing
Safetynet status: Pass without Magisk
Sourceforge username: mst-2069
Telegram username: @Ken_kaneki_69
XDA Profile (if exists): https://forum.xda-developers.com/m/dhimanparas20.8789230/

Signed-off-by: dhimanparas20 <dhimanparas20@gmail.com>